### PR TITLE
Updating parallel and touches

### DIFF
--- a/docs/api/actions/touches.md
+++ b/docs/api/actions/touches.md
@@ -9,7 +9,7 @@ Creates a composite action that tracks a collection of `x`/`y` movements from mu
 
 `touches(e <MouseEvent | TouchEvent>, props <Object>)`
 
-Mouse movements will only ever generate a single touch.
+Mouse movements will generate a single touch.
 
 ## Example
 
@@ -22,9 +22,9 @@ document.addEventListener('touchstart', (e) => {
   if (action) action.stop();
   action = touches(e, {
     preventDefault: true,
-    onUpdate: ({ touches, touchCount }) => {
+    onUpdate: (touches) => {
       console.log(
-        `Touch count: ${touchCount},
+        `Touch count: ${touches.length},
          Touch coordinates: ${touches}`)
     }
   }).start();
@@ -34,15 +34,6 @@ document.addEventListener('touchend', (e) => {
   if (action) action.stop();
 });
 ```
-
-## Properties
-
-* `touches <Array<{x:Number,y:Number}>>`
-  * list of client {x,y} coordinates from the TouchEvent's `touches`
-  * mouse events are always a list of one
-* `touchCount <Number>`
-  * count of `touches` in the `touchmove` event
-  * mouse events will always be `1`
 
 ## Props
 

--- a/src/actions/composite.js
+++ b/src/actions/composite.js
@@ -7,7 +7,7 @@ class CompositeAction extends Action {
     super(remainingProps);
     this.current = {};
     this.actionKeys = [];
-    this.addActions(props.actions);
+    this.addActions(actions);
   }
 
   addActions(actions) {
@@ -18,7 +18,7 @@ class CompositeAction extends Action {
 
       this[key] = actions[key];
 
-      const onUpdate = (v) => this.current[key] = v;;
+      const onUpdate = (v) => this.current[key] = v;
 
       // Immediately update with the current action state
       onUpdate(this[key].get());

--- a/src/actions/parallel.js
+++ b/src/actions/parallel.js
@@ -1,22 +1,25 @@
 import Action from './';
+import { onFrameUpdate } from '../framesync';
 
 class Parallel extends Action {
-  constructor() {
+  constructor(props) {
     const { actions, ...remainingProps } = props;
     super(remainingProps);
+    this.actions = [];
     this.current = [];
     this.addActions(actions);
   }
 
   addAction(action) {
-    const { actions } = this.props;
+    if (this.actions.indexOf(action) !== -1) return;
 
-    if (actions.indexOf(action) !== -1) return;
+    this.actions.push(action);
 
-    actions.push(action);
-
-    const i = actions.length - 1;
-    const onUpdate = (v) => this.current[i] = v;
+    const i = this.actions.length - 1;
+    const onUpdate = (v) => {
+      this.current[i] = v;
+      onFrameUpdate(this.scheduledUpdate);
+    };
 
     onUpdate(action.get());
 
@@ -32,23 +35,24 @@ class Parallel extends Action {
   }
 
   onStart() {
-    const { actions } = this.props;
-    this.numActiveActions = actions.length;
-    actions.forEach((action) => action.start());
+    this.numActiveActions = this.actions.length;
+    this.actions.forEach((action) => action.start());
   }
 
   onStop() {
-    const { actions } = this.props;
-    actions.forEach((action) => action.stop());
+    this.actions.forEach((action) => action.stop());
   }
 
   getVelocity() {
-    const { actions } = this.props;
-    return actions.map((action) => action.getVelocity());
+    return this.actions.map((action) => action.getVelocity());
   }
 
   isActionComplete() {
     return (this.numActiveActions === 0);
+  }
+
+  getAction(i) {
+    return this.actions[i];
   }
 }
 

--- a/src/actions/touches.js
+++ b/src/actions/touches.js
@@ -1,3 +1,4 @@
+import value from './value';
 import composite from './composite';
 import parallel from './parallel';
 
@@ -22,29 +23,30 @@ function createTouches(initialTouches, { eventToTouches, moveEvent, ...props }) 
   return touches;
 }
 
-function mapCoordsToActions(coords) { 
+function mapCoordsToActions(coords) {
   let actions = [];
-  for (var i = 0; i < coords.length; i++) {
+  for (let i = 0; i < coords.length; i++) {
     const { x, y } = coords[i];
     actions[i] = composite({
       x: value(x),
       y: value(y)
     });
   }
-  return composite(actions);
+  return actions;
 }
 
-function updateActionWithTouches(action, newTouches) {
-  for (const i in newTouches) {
+function updateActionWithTouches(touches, newTouches) {
+  for (let i = 0; i < newTouches.length; i++) {
     const { x, y } = newTouches[i];
-    if (action[i] !== null) {
-      action[i].x.set(x);
-      action[i].y.set(y);
+    const touchAction = touches.getAction(i);
+    if (touchAction !== undefined) {
+      touchAction.x.set(x);
+      touchAction.y.set(y);
     } else {
-      action[i] = composite({
+      touches.addAction(composite({
         x: value(x),
         y: value(y)
-      });
+      }));
     }
   }
 }
@@ -52,7 +54,7 @@ function updateActionWithTouches(action, newTouches) {
 const mouseEventToTouches = ({ pageX, pageY }) => [{ x: pageX, y: pageY }];
 const touchEventToTouches = ({ touches }) => extractCoords(touches);
 
-function extractCoords(touches) { 
+function extractCoords(touches) {
   let coords = [];
   for (var i = 0; i < touches.length; i++) {
     const { clientX, clientY } = touches[i];


### PR DESCRIPTION
Hi @mars!

Sorry this took much longer to get to than I'd prefer.

Here, I've updated `parallel` to be more accommodating to an iterative list of touches, and updated `touches` to use this (I can see why it was required to maintain a `touchCount`)

*Edit*: I should add, this is untested. Once I've got everything merged in we can put it in the `packages/popmotion-react/` storybook playground, which is a good place to test new functionality.
